### PR TITLE
chore: pin version to 2 before `latest` upgrades to 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@vue/composition-api": "latest",
-    "vue": "latest"
+    "vue": "^2"
   },
   "devDependencies": {
     "@vue/runtime-dom": "latest",


### PR DESCRIPTION
I found it was confusing to consider whether vue@latest was vue 2 or vue 3 in the reference code I was using. This makes the commitment to vue2 permanent in the branch. 