### PR TITLE
Add an example of a component using an index file

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,13 @@
 <template>
   <img alt="Vue logo" src="./assets/logo.png" />
   <HelloWorld msg="Hello Vue 3 + TypeScript + Vite" />
+  <HelloIndex msg="Hello Vue 3 + TypeScript + Vite" />
   {{ $t /* $t(key: "hello"): void */ }}
 </template>
 
 <script lang="ts" setup>
 import HelloWorld from './components/HelloWorld.vue'
+import HelloIndex from './components/HelloIndex';
 </script>
 
 <style>

--- a/src/components/HelloIndex/index.vue
+++ b/src/components/HelloIndex/index.vue
@@ -1,0 +1,78 @@
+<template>
+    <h1>{{ msg }}</h1>
+  
+    <p>
+      Recommended IDE setup:
+      <a href="https://code.visualstudio.com/" target="_blank">VSCode</a>
+      +
+      <a href="https://github.com/johnsoncodehk/volar" target="_blank">Volar</a>
+    </p>
+  
+    <p>
+      <a href="https://vitejs.dev/guide/features.html" target="_blank">Vite Docs</a> |
+      <a href="https://v3.vuejs.org/" target="_blank">Vue 3 Docs</a>
+    </p>
+  
+    <button @click="count++">count is: {{ count }}</button>
+    <p>
+      Edit
+      <code>components/HelloeIndex.vue</code> to test hot module replacement.
+    </p>
+  </template>
+
+<script lang="ts">
+  export default {
+    name: 'HelloIndex',
+  }
+</script>
+
+<script lang="ts" setup>
+  import { ref } from 'vue'
+  
+  defineProps<{ msg: string }>()
+  
+  const count = ref(0)
+  </script>
+  
+  <style scoped>
+  a {
+    color: #42b983;
+  }
+  
+  label {
+    margin: 0 0.5em;
+    font-weight: bold;
+  }
+  
+  code {
+    background-color: #eee;
+    padding: 2px 4px;
+    border-radius: 4px;
+    color: #304455;
+  }
+  </style>
+  
+  <preview lang="md">
+  # This is preview page of HelloeIndex.vue
+  
+  ## Props
+  
+  | Props       | Description    |
+  | ----------- | -------------- |
+  | msg         | Title message  |
+  
+  ## Examples
+  
+  <script setup>
+  const msgs = [
+    'Hello Peter',
+    'Hello John',
+  ];
+  </script>
+  
+  <template v-for="msg in msgs">
+    <slot :msg="msg"></slot>
+  </template>
+  
+  </preview>
+  

--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -1,0 +1,4 @@
+declare module "*" {
+  import Vue from "vue";
+  export default Vue;
+}


### PR DESCRIPTION
We have a code base that has a pattern library approach that has additional files. for components in the component folder and we use `index.vue` for the component files themselves.

We've found that volar doesn't recognise this structure for auto imports.

This adds an example to the starter project to test this functionality